### PR TITLE
ignores_csrf_attack: true

### DIFF
--- a/lib/ueberauth/strategy/passwordless.ex
+++ b/lib/ueberauth/strategy/passwordless.ex
@@ -74,7 +74,7 @@ defmodule Ueberauth.Strategy.Passwordless do
   Per default, Passwordless will redirect to "/" after the request phase is completed.
   """
 
-  use Ueberauth.Strategy
+  use Ueberauth.Strategy, ignores_csrf_attack: true
 
   alias Ueberauth.Auth.{Extra, Info}
   alias Ueberauth.Strategy.Passwordless.Store


### PR DESCRIPTION
Sometimes email clients mess with the request and it ends up looking like a csrf attack.